### PR TITLE
Feat 1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+pandas = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 pandas = "*"
+numpy = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e3a50cd2a235febb110f7969c9bb76ccb0b8c53352b4361b6f68bb8035885654"
+            "sha256": "68a0d4806298337f325d8ae935c41bbfed54be9596b0093552c92927bf47db17"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -51,7 +51,8 @@
                 "sha256:e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617",
                 "sha256:e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c"
             ],
-            "markers": "python_version >= '3.12'",
+            "index": "pypi",
+            "markers": "python_version < '3.13' and python_version >= '3.9'",
             "version": "==1.26.1"
         },
         "pandas": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "198f904cd8ec49da8176ca95d76e96b851887f729816bff095edc7aebdb54bd8"
+            "sha256": "e3a50cd2a235febb110f7969c9bb76ccb0b8c53352b4361b6f68bb8035885654"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -15,7 +15,109 @@
             }
         ]
     },
-    "default": {},
+    "default": {
+        "numpy": {
+            "hashes": [
+                "sha256:06934e1a22c54636a059215d6da99e23286424f316fddd979f5071093b648668",
+                "sha256:1c59c046c31a43310ad0199d6299e59f57a289e22f0f36951ced1c9eac3665b9",
+                "sha256:1d1bd82d539607951cac963388534da3b7ea0e18b149a53cf883d8f699178c0f",
+                "sha256:1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5",
+                "sha256:3649d566e2fc067597125428db15d60eb42a4e0897fc48d28cb75dc2e0454e53",
+                "sha256:59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2",
+                "sha256:6081aed64714a18c72b168a9276095ef9155dd7888b9e74b5987808f0dd0a974",
+                "sha256:6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f",
+                "sha256:76ff661a867d9272cd2a99eed002470f46dbe0943a5ffd140f49be84f68ffc42",
+                "sha256:78ca54b2f9daffa5f323f34cdf21e1d9779a54073f0018a3094ab907938331a2",
+                "sha256:82e871307a6331b5f09efda3c22e03c095d957f04bf6bc1804f30048d0e5e7af",
+                "sha256:8ab9163ca8aeb7fd32fe93866490654d2f7dda4e61bc6297bf72ce07fdc02f67",
+                "sha256:9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e",
+                "sha256:97e5d6a9f0702c2863aaabf19f0d1b6c2628fbe476438ce0b5ce06e83085064c",
+                "sha256:9f42284ebf91bdf32fafac29d29d4c07e5e9d1af862ea73686581773ef9e73a7",
+                "sha256:a03fb25610ef560a6201ff06df4f8105292ba56e7cdd196ea350d123fc32e24e",
+                "sha256:a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908",
+                "sha256:af22f3d8e228d84d1c0c44c1fbdeb80f97a15a0abe4f080960393a00db733b66",
+                "sha256:afd5ced4e5a96dac6725daeb5242a35494243f2239244fad10a90ce58b071d24",
+                "sha256:b9d45d1dbb9de84894cc50efece5b09939752a2d75aab3a8b0cef6f3a35ecd6b",
+                "sha256:bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e",
+                "sha256:c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe",
+                "sha256:cd7837b2b734ca72959a1caf3309457a318c934abef7a43a14bb984e574bbb9a",
+                "sha256:cdd9ec98f0063d93baeb01aad472a1a0840dee302842a2746a7a8e92968f9575",
+                "sha256:d1cfc92db6af1fd37a7bb58e55c8383b4aa1ba23d012bdbba26b4bcca45ac297",
+                "sha256:d1d2c6b7dd618c41e202c59c1413ef9b2c8e8a15f5039e344af64195459e3104",
+                "sha256:d2984cb6caaf05294b8466966627e80bf6c7afd273279077679cb010acb0e5ab",
+                "sha256:d58e8c51a7cf43090d124d5073bc29ab2755822181fcad978b12e144e5e5a4b3",
+                "sha256:d78f269e0c4fd365fc2992c00353e4530d274ba68f15e968d8bc3c69ce5f5244",
+                "sha256:dcfaf015b79d1f9f9c9fd0731a907407dc3e45769262d657d754c3a028586124",
+                "sha256:e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617",
+                "sha256:e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c"
+            ],
+            "markers": "python_version >= '3.12'",
+            "version": "==1.26.1"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:02304e11582c5d090e5a52aec726f31fe3f42895d6bfc1f28738f9b64b6f0614",
+                "sha256:0489b0e6aa3d907e909aef92975edae89b1ee1654db5eafb9be633b0124abe97",
+                "sha256:05674536bd477af36aa2effd4ec8f71b92234ce0cc174de34fd21e2ee99adbc2",
+                "sha256:25e8474a8eb258e391e30c288eecec565bfed3e026f312b0cbd709a63906b6f8",
+                "sha256:29deb61de5a8a93bdd033df328441a79fcf8dd3c12d5ed0b41a395eef9cd76f0",
+                "sha256:366da7b0e540d1b908886d4feb3d951f2f1e572e655c1160f5fde28ad4abb750",
+                "sha256:3bcad1e6fb34b727b016775bea407311f7721db87e5b409e6542f4546a4951ea",
+                "sha256:4c3f32fd7c4dccd035f71734df39231ac1a6ff95e8bdab8d891167197b7018d2",
+                "sha256:4cdb0fab0400c2cb46dafcf1a0fe084c8bb2480a1fa8d81e19d15e12e6d4ded2",
+                "sha256:4f99bebf19b7e03cf80a4e770a3e65eee9dd4e2679039f542d7c1ace7b7b1daa",
+                "sha256:58d997dbee0d4b64f3cb881a24f918b5f25dd64ddf31f467bb9b67ae4c63a1e4",
+                "sha256:75ce97667d06d69396d72be074f0556698c7f662029322027c226fd7a26965cb",
+                "sha256:84e7e910096416adec68075dc87b986ff202920fb8704e6d9c8c9897fe7332d6",
+                "sha256:9e2959720b70e106bb1d8b6eadd8ecd7c8e99ccdbe03ee03260877184bb2877d",
+                "sha256:9e50e72b667415a816ac27dfcfe686dc5a0b02202e06196b943d54c4f9c7693e",
+                "sha256:a0dbfea0dd3901ad4ce2306575c54348d98499c95be01b8d885a2737fe4d7a98",
+                "sha256:b407381258a667df49d58a1b637be33e514b07f9285feb27769cedb3ab3d0b3a",
+                "sha256:b8bd1685556f3374520466998929bade3076aeae77c3e67ada5ed2b90b4de7f0",
+                "sha256:c1f84c144dee086fe4f04a472b5cd51e680f061adf75c1ae4fc3a9275560f8f4",
+                "sha256:c747793c4e9dcece7bb20156179529898abf505fe32cb40c4052107a3c620b49",
+                "sha256:cc1ab6a25da197f03ebe6d8fa17273126120874386b4ac11c1d687df288542dd",
+                "sha256:dc3657869c7902810f32bd072f0740487f9e030c1a3ab03e0af093db35a9d14e",
+                "sha256:f5ec7740f9ccb90aec64edd71434711f58ee0ea7f5ed4ac48be11cfa9abf7317",
+                "sha256:fecb198dc389429be557cde50a2d46da8434a17fe37d7d41ff102e3987fd947b",
+                "sha256:ffa8f0966de2c22de408d0e322db2faed6f6e74265aa0856f3824813cf124363"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.1.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b",
+                "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"
+            ],
+            "version": "==2023.3.post1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
+                "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
+            ],
+            "markers": "python_version >= '2'",
+            "version": "==2023.3"
+        }
+    },
     "develop": {
         "colorama": {
             "hashes": [

--- a/lognorm/__init__.py
+++ b/lognorm/__init__.py
@@ -1,6 +1,15 @@
 """
 """
 
+import sys
+
+from .gct import GCT
+from .lognorm import log_normalize
+
 
 def main():
-    pass
+    _, source, destination = sys.argv
+
+    gct = GCT(source)
+    gct.dataframe = log_normalize(gct.dataframe)
+    gct.write(destination)

--- a/lognorm/gct.py
+++ b/lognorm/gct.py
@@ -1,6 +1,7 @@
 """
 """
 
+import csv
 import io
 import sys
 
@@ -36,14 +37,15 @@ class GCT:
         """
         self._dataframe = value
 
-    def export(self, buffer: io.TextIOBase):
+    def export(self, buffer: io.TextIOBase, **kwargs):
         """
         :param buffer:
         """
-        buffer.write(self._version)
+        buffer.write(f"{self._version}\n")
         buffer.write(f"{self._delimiter.join(map(str, self.dataframe.shape))}\n")
 
-        self.dataframe.to_csv(buffer, sep=self._delimiter)
+
+        self.dataframe.to_csv(buffer, sep=self._delimiter, quoting=csv.QUOTE_NONE, **kwargs)
 
     def write(self, path: str):
         """

--- a/lognorm/gct.py
+++ b/lognorm/gct.py
@@ -1,0 +1,53 @@
+"""
+"""
+
+import io
+import sys
+
+import pandas as pd
+
+
+class GCT:
+    """
+    :param path:
+    """
+    _version = "#1.2"
+    _delimiter = "\t"
+    _header = 2
+    _index_col = [0, 1]
+
+    def __init__(self, source: str):
+        self._source = source
+
+        self._dataframe = pd.read_table(
+            self._source, delimiter=self._delimiter, index_col=self._index_col,
+            header=self._header
+        )
+
+    @property
+    def dataframe(self) -> pd.DataFrame:
+        """
+        """
+        return self._dataframe
+
+    @dataframe.setter
+    def dataframe(self, value: pd.DataFrame) -> None:
+        """
+        """
+        self._dataframe = value
+
+    def export(self, buffer: io.TextIOBase):
+        """
+        :param buffer:
+        """
+        buffer.write(self._version)
+        buffer.write(f"{self._delimiter.join(map(str, self.dataframe.shape))}\n")
+
+        self.dataframe.to_csv(buffer, sep=self._delimiter)
+
+    def write(self, path: str):
+        """
+        :param path:
+        """
+        with open(path, "w", encoding="utf-8", newline="") as file:
+            self.export(file)

--- a/lognorm/lognorm.py
+++ b/lognorm/lognorm.py
@@ -2,13 +2,14 @@
 """
 
 import numpy as np
-import pandas as pd
 
 
-def log_normalize(df: pd.DataFrame) -> pd.DataFrame:
+def log_normalize(
+    array: np.ndarray[None, np.dtype[np.float64]]
+) -> np.ndarray[None, np.dtype[np.float64]]:
     """
     :param df:
     :return:
     """
-    df[df > 0] = np.log(df[df > 0])
-    return df
+    array[array > 0] = np.log(array[array > 0])
+    return array

--- a/lognorm/lognorm.py
+++ b/lognorm/lognorm.py
@@ -5,34 +5,7 @@ import numpy as np
 import pandas as pd
 
 
-class GCT:
-    """
-    """
-    _delimiter = "\t"
-    _header = 2
-    _index_col = [0, 1]
-
-    @classmethod
-    def read(cls, path: str) -> pd.DataFrame:
-        """
-        :param path:
-        :return:
-        """
-        return pd.read_table(
-            path, delimiter=cls._delimiter, headers=cls._header, index_col=cls._index_col
-        )
-    
-    @classmethod
-    def write(cls, df: pd.DataFrame) -> str:
-        """
-        :param df:
-        :param path:
-        :return:
-        """
-        pass
-
-
-def lognormalize(df: pd.DataFrame) -> pd.DataFrame:
+def log_normalize(df: pd.DataFrame) -> pd.DataFrame:
     """
     :param df:
     :return:

--- a/lognorm/lognorm.py
+++ b/lognorm/lognorm.py
@@ -1,2 +1,41 @@
 """
 """
+
+import numpy as np
+import pandas as pd
+
+
+class GCT:
+    """
+    """
+    _delimiter = "\t"
+    _header = 2
+    _index_col = [0, 1]
+
+    @classmethod
+    def read(cls, path: str) -> pd.DataFrame:
+        """
+        :param path:
+        :return:
+        """
+        return pd.read_table(
+            path, delimiter=cls._delimiter, headers=cls._header, index_col=cls._index_col
+        )
+    
+    @classmethod
+    def write(cls, df: pd.DataFrame) -> str:
+        """
+        :param df:
+        :param path:
+        :return:
+        """
+        pass
+
+
+def lognormalize(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    :param df:
+    :return:
+    """
+    df[df > 0] = np.log(df[df > 0])
+    return df

--- a/lognorm/tests/test_gct.py
+++ b/lognorm/tests/test_gct.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for :py:mod:`lognorm.gct`.
+"""
+
+import io
+import urllib.request
+
+import pandas as pd
+import pytest
+
+from lognorm.gct import GCT
+
+
+@pytest.fixture(scope="module")
+def gct(request: pytest.FixtureRequest) -> GCT:
+    """
+    :param request:
+    :return:
+    """
+    return GCT(request.param)
+
+
+@pytest.mark.parametrize(
+    "gct", [
+        "https://datasets.genepattern.org/data/all_aml/all_aml_train.gct",
+        "https://datasets.genepattern.org/data/test_data/BRCA_minimal_60x19.gct",
+        "https://datasets.genepattern.org/data/test_data/BRCA_large_20783x40.gct"
+    ], indirect=True
+)
+class TestGCT:
+    """
+    Unit tests for :py:class:`GCT`.
+    """
+    def test_dataframe(self, gct: GCT):
+        """
+        Unit test for :py:attr:`GCT.dataframe`.
+        """
+        with urllib.request.urlopen(gct._source) as response:
+            version = response.readline().decode("utf-8").strip()
+            assert version == GCT._version, gct._source
+
+            shape = tuple(map(int, response.readline().decode("utf-8").strip().split()))
+            assert shape == gct.dataframe.shape, gct._source
+
+            columns = response.readline().decode("utf-8").strip().split()
+            assert pd.Index(columns[2:]).equals(gct.dataframe.columns), gct._source
+    
+    def test_export(self, gct: GCT):
+        """
+        Unit test for :py:meth:`GCT.export`.
+        """
+        with urllib.request.urlopen(gct._source) as response:
+            content = response.read()
+            
+        with io.StringIO() as buffer:
+            gct.export(buffer, lineterminator="\n")
+
+            assert buffer.getvalue().encode() == content, gct._source

--- a/lognorm/tests/test_lognorm.py
+++ b/lognorm/tests/test_lognorm.py
@@ -1,3 +1,35 @@
 """
 Unit tests for :py:mod:`lognorm.lognorm`.
 """
+
+import numpy as np
+import pytest
+
+from lognorm import lognorm
+
+
+@pytest.mark.parametrize(
+    ("array", "expected"), [
+        (np.array([1], dtype=np.float64), np.array([0], dtype=np.float64)),
+        (np.array([0], dtype=np.float64), np.array([0], dtype=np.float64)),
+        (np.array([-1], dtype=np.float64), np.array([-1], dtype=np.float64)),
+        (np.array([np.e], dtype=np.float64), np.array([1], dtype=np.float64)),
+        (np.array([-np.e], dtype=np.float64), np.array([-np.e], dtype=np.float64)),
+
+        (np.array([1, np.e, np.e ** 2], dtype=np.float64), np.array([0, 1, 2], dtype=np.float64)),
+        (np.array([-np.e ** 2, -np.e, -1], dtype=np.float64), np.array([-np.e ** 2, -np.e, -1], dtype=np.float64)),
+        (np.array([0, 1, np.e, np.e ** 2, np.e ** 3], dtype=np.float64), np.array([0, 0, 1, 2, 3], dtype=np.float64)),
+        (np.array([-np.e ** 3, -np.e ** 2, -np.e, -1, 0], dtype=np.float64), np.array([-np.e ** 3, -np.e ** 2, -np.e, -1, 0], dtype=np.float64)),
+        (np.array([-np.e, -1, 0, 1, np.e], dtype=np.float64), np.array([-np.e, -1, 0, 0, 1], dtype=np.float64)),
+
+        (np.arange(1, 101, dtype=np.float64), np.log(np.arange(1, 101, dtype=np.float64))),
+        (np.arange(-100, 1, dtype=np.float64), np.arange(-100, 1, dtype=np.float64)),
+        (np.e ** np.arange(1, 101), np.arange(1, 101, dtype=np.float64)),
+        (-np.e ** np.arange(-100, 1, dtype=np.float64), -np.e ** np.arange(-100, 1, dtype=np.float64)),
+    ]
+)
+def test_log_normalize(array: np.ndarray, expected: np.ndarray):
+    """
+    Unit test for :py:func:`lognorm.log_normalize`.
+    """
+    assert np.array_equal(lognorm.log_normalize(array), expected), array


### PR DESCRIPTION
Write a Python script to read the data contained in an input GCT file, log-normalize the data, and output the modified data as a GCT file.

```python
>>> import lognorm
>>> gct = lognorm.GCT(<source-path>)
>>> gct.dataframe = lognorm.log_normalize(gct.dataframe)
>>> gct.write(<destination-path>)
```

---

Failing test cases:
- `lognorm/tests/test_gct.py::TestGCT::test_export[https://datasets.genepattern.org/data/test_data/BRCA_minimal_60x19.gct]`: Inconsistent representation of integers in [original GCT file](https://www.diffchecker.com/YbN4UIFM/).
- `lognorm/tests/test_lognorm.py::test_log_normalize[array12-expected12]`: Floating-point error ($\ln({e}^{8}) \ne 8$ and $\ln({e}^{16}) \ne 16$).

---

Close #1 